### PR TITLE
Change entrypoint and update external dependencies for Vite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,11 @@
 name: Deploy
 on:
   push:
-    branches: master
+    branches: 
+    - master
   pull_request:
-    branches: master
+    branches:
+    - master
 
 jobs:
   deploy:
@@ -24,11 +26,11 @@ jobs:
           deno-version: v2.x
 
       - name: Build step
-        run: "deno task build --reload"
+        run: "deno task build"
 
       - name: Upload to Deno Deploy
         uses: denoland/deployctl@v1
         with:
           project: "vcangel"
-          entrypoint: "main.ts"
+          entrypoint: "_fresh/server.js"
           root: "."

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,9 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   plugins: [fresh(), tailwindcss()],
+  build: {
+    rolldownOptions: {
+      external: ["fresh/runtime"],
+    }
+  }
 });


### PR DESCRIPTION
This pull request updates the GitHub Actions deployment workflow to improve clarity and align the deployment process with recent changes in the project structure. The most notable changes are in the workflow trigger configuration and the build and deployment steps.

**Workflow configuration updates:**

* The `branches` configuration for both `push` and `pull_request` events now uses YAML array syntax for clarity and consistency.

**Build and deployment process changes:**

* The build step no longer uses the `--reload` flag, which may improve build times by avoiding unnecessary cache invalidation.
* The deployment entry point has been updated from `main.ts` to `_fresh/server.js`, reflecting a change in the project's deployment structure.
This pull request updates the deployment workflow and build configuration for the project. The main changes include refining the GitHub Actions workflow for deployment, updating the build and deployment steps, and adjusting the Vite configuration to handle external dependencies.

**Deployment workflow and build process updates:**

* Changed the `branches` configuration in `.github/workflows/deploy.yml` for both `push` and `pull_request` triggers to use YAML array syntax for better clarity and extensibility.
* Updated the build step in the GitHub Actions deployment workflow to remove the `--reload` flag from the Deno build command, likely to improve build performance or reliability.
* Changed the Deno Deploy entrypoint from `main.ts` to `_fresh/server.js` in the workflow, reflecting an update in the project's entry file structure.

**Build configuration improvements:**

* Added a `build` section to `vite.config.ts` with `rolldownOptions` to mark `fresh/runtime` as an external dependency, which can help reduce bundle size and avoid bundling runtime code unnecessarily.